### PR TITLE
Add employee table component

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { AboutComponent } from './shared/components/about/about.component';
 import { RegisterComponent } from './shared/components/register/register.component';
 import { LoginComponent } from './shared/components/login/login.component';
 import { HomeComponent } from './shared/components/home/home.component';
+import { EmployeesComponent } from './shared/components/employees/employees.component';
 
 const routes: Routes = [
   { path: 'home', component: HomeComponent },
@@ -15,6 +16,7 @@ const routes: Routes = [
   { path: 'about', component: AboutComponent },
   { path: 'contact', component: ContactComponent },
   { path: 'header', component: HeaderComponent },
+  { path: 'employees', component: EmployeesComponent },
   { path: '', redirectTo: '/home', pathMatch: 'full' },
   {path: 'code-demo', component:CodeDemoComponent},
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule, provideClientHydration, withEventReplay } from '@angular
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { HttpClientModule } from '@angular/common/http';
 import { HeaderComponent } from './core/components/header/header.component';
 import { FooterComponent } from './core/components/footer/footer.component';
 import { LoginComponent } from './shared/components/login/login.component';
@@ -13,6 +14,7 @@ import { CodeDemoComponent } from './shared/components/code-demo/code-demo.compo
 import { AboutComponent } from './shared/components/about/about.component';
 import { ContactComponent } from './shared/components/contact/contact.component';
 import { HomeComponent } from './shared/components/home/home.component';
+import { EmployeesComponent } from './shared/components/employees/employees.component';
 
 @NgModule({
   declarations: [
@@ -26,11 +28,13 @@ import { HomeComponent } from './shared/components/home/home.component';
     CodeDemoComponent,
     AboutComponent,
     ContactComponent,
-    HomeComponent
+    HomeComponent,
+    EmployeesComponent
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    HttpClientModule
   ],
   providers: [
     provideClientHydration(withEventReplay())

--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -11,7 +11,8 @@ export class HeaderComponent {
   navItems = [
     { name: 'Home', link: '/home' },
     { name: 'About', link: '/about' },
-    { name: 'Contact', link: '/contact' }
+    { name: 'Contact', link: '/contact' },
+    { name: 'Employees', link: '/employees' }
   ];
   rightNavItems = [
     { name: 'Login', link: '/login' },

--- a/src/app/shared/components/employees/employees.component.html
+++ b/src/app/shared/components/employees/employees.component.html
@@ -1,0 +1,21 @@
+<div class="container">
+  <h2 class="mb-3">Employees</h2>
+  <table class="table table-bordered table-striped">
+    <thead class="table-dark">
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Phone</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let emp of employees">
+        <td>{{ emp.id }}</td>
+        <td>{{ emp.name }}</td>
+        <td>{{ emp.email }}</td>
+        <td>{{ emp.phone }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/shared/components/employees/employees.component.scss
+++ b/src/app/shared/components/employees/employees.component.scss
@@ -1,0 +1,1 @@
+/* Add component-specific styles here */

--- a/src/app/shared/components/employees/employees.component.spec.ts
+++ b/src/app/shared/components/employees/employees.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { EmployeesComponent } from './employees.component';
+
+describe('EmployeesComponent', () => {
+  let component: EmployeesComponent;
+  let fixture: ComponentFixture<EmployeesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EmployeesComponent],
+      imports: [HttpClientTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmployeesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/employees/employees.component.ts
+++ b/src/app/shared/components/employees/employees.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { Employee, EmployeeService } from '../../services/employee.service';
+
+@Component({
+  selector: 'app-employees',
+  templateUrl: './employees.component.html',
+  styleUrl: './employees.component.scss'
+})
+export class EmployeesComponent implements OnInit {
+  employees: Employee[] = [];
+
+  constructor(private employeeService: EmployeeService) {}
+
+  ngOnInit(): void {
+    this.employeeService.getEmployees().subscribe({
+      next: data => this.employees = data,
+      error: err => console.error('Failed to load employees', err)
+    });
+  }
+}

--- a/src/app/shared/services/employee.service.ts
+++ b/src/app/shared/services/employee.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Employee {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmployeeService {
+  private apiUrl = 'https://motopartz.gerasim.in/api/Employee/all';
+
+  constructor(private http: HttpClient) {}
+
+  getEmployees(): Observable<Employee[]> {
+    return this.http.get<Employee[]>(this.apiUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- fetch employees with a service
- show employee table with bootstrap styles
- expose new Employees route and update navigation
- register HTTP client module

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842836448b88321bd876bd1e4760b44