### PR TITLE
Fix employees component declaration

### DIFF
--- a/src/app/shared/components/employees/employees.component.ts
+++ b/src/app/shared/components/employees/employees.component.ts
@@ -3,6 +3,7 @@ import { Employee, EmployeeService } from '../../services/employee.service';
 
 @Component({
   selector: 'app-employees',
+  standalone: false,
   templateUrl: './employees.component.html',
   styleUrl: './employees.component.scss'
 })


### PR DESCRIPTION
## Summary
- mark EmployeesComponent as non-standalone to match NgModule declarations

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68428614b0248321964b76fd29296dda